### PR TITLE
Fix license (use a valid SPDX license identifier)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "libsieve-php is a library to manage and modify sieve (RFC5228) scripts.",
     "keywords": ["sieve", "filters", "mail"],
     "type": "library",
-    "license": "GPLv3",
+    "license": "GPL-3.0-or-later",
     "homepage": "https://sourceforge.net/projects/libsieve-php/",
     "support": {
         "issues": "https://github.com/ProtonMail/libsieve-php/issues"


### PR DESCRIPTION
Fix license name for packagist:

```
Skipped branch master, Invalid package information: 
License "GPLv3" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```