### PR TITLE
Codecov hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_script:
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
 
-#after_success:
-#  - bash <(curl -s https://codecov.io/bash)
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Bringing back codecov, at least to have history of coverages, we can disable the PR bot separately if needed.