### PR TITLE
Add :create argument to fileinto

### DIFF
--- a/lib/extensions/mailbox.xml
+++ b/lib/extensions/mailbox.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' standalone='yes'?>
+
+<extension name="mailbox">
+
+	<tagged-argument extends="fileinto">
+		<parameter type="tag" name="create" regex="create" occurrence="optional" />
+	</tagged-argument>
+
+</extension>


### PR DESCRIPTION
This patch adds `:create` argument to `fileinto` through the `mailbox` extension.

See: https://www.rfc-editor.org/rfc/rfc5490.html#section-3.2